### PR TITLE
docs: add MIT license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ cd autonomous-project
 
 ## Testes
 > Ainda não há suíte de testes configurada. Quando houver, informe o comando recomendado para rodá-los.
+
+## Licença
+Este projeto está licenciado sob a licença MIT. Consulte o arquivo [LICENSE](LICENSE).
+


### PR DESCRIPTION
## Summary
- add README license section pointing to MIT license file

## Testing
- not run (documentation-only change)
